### PR TITLE
Remove call to UIApplication.shared

### DIFF
--- a/Sources/KeyboardLayoutGuide/KeyboardLayoutGuide.swift
+++ b/Sources/KeyboardLayoutGuide/KeyboardLayoutGuide.swift
@@ -155,7 +155,7 @@ extension Notification {
         } else {
             // Weirdly enough UIKeyboardFrameEndUserInfoKey doesn't have the same behaviour
             // in ios 10 or iOS 11 so we can't rely on v.cgRectValue.width
-            let screenHeight = UIApplication.shared.keyWindow?.bounds.height ?? UIScreen.main.bounds.height
+            let screenHeight = UIScreen.main.bounds.height
             return screenHeight - keyboardFrame.cgRectValue.minY
         }
     }


### PR DESCRIPTION
## Why did I make these changes?

This appears to be expected behavior in Xcode 13 beta 3 with Swift Package Manager, based on this [Apple Developer Forums](https://developer.apple.com/forums/thread/685103) thread and this [Swift forums post](https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/13). The Apple engineer in the second link recommends dealing with this by marking declarations as unavailable to app extensions when they use APIs that are unavailable to app extensions.

Update: It looks like the Swift team is [reconsidering how this behaves](https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/33).

## What are the changes?
Remove any calls to `UIApplication.shared`. Found that it wasn't necessary to ensure the keyboard was shown.

For testing I had to exclude the `KeyboardLayoutGuide` in the `AcknowledgementsGenerate.swift` file for Vibe Up to compile.

## TODO
- [ ] Update package version if this PR is approved so that we can do a release.

## How was this tested?
All testing was done via the Vibe Up project by copying this project into its `Packages` directory.
- Tested via Xcode 13 beta 3 on my physical 14.6 iPhone 11 Pro and on 15 Simulator.
- Tested via Xcode 12.4 on a iOS 14.4 iPhone SE and iPhone 12

## Screenshots
iOS 14.4 Sim SE | iOS 14.4 Sim 12 | iOS 14.6 Physical 11 Pro | iOS 15 Sim 12
--- | --- | --- | --- 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1082672/127145752-208239b7-276b-4475-b820-519942edee76.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/1082672/127145813-da1546b3-b265-4ea1-b15e-b749f64fc540.png"> | <img width="300" src="https://user-images.githubusercontent.com/1082672/127146383-bca693d9-c3d4-4562-940d-9ebab09f5218.jpeg" /> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/1082672/127146974-2fad4e3b-1f24-4084-bc18-860b6377b7f5.png">



